### PR TITLE
Fix template config for `inMemoryNode`

### DIFF
--- a/templates/hardhat/solidity/hardhat.config.ts
+++ b/templates/hardhat/solidity/hardhat.config.ts
@@ -33,7 +33,7 @@ const config: HardhatUserConfig = {
     },
     inMemoryNode: {
       url: "http://127.0.0.1:8011",
-      ethNetwork: "", // in-memory node doesn't support eth node; removing this line will cause an error
+      ethNetwork: "localhost", // in-memory node doesn't support eth node; removing this line will cause an error
       zksync: true,
     },
     hardhat: {

--- a/templates/hardhat/vyper/hardhat.config.ts
+++ b/templates/hardhat/vyper/hardhat.config.ts
@@ -31,7 +31,7 @@ const config: HardhatUserConfig = {
     },
     inMemoryNode: {
       url: "http://127.0.0.1:8011",
-      ethNetwork: "", // in-memory node doesn't support eth node; removing this line will cause an error
+      ethNetwork: "localhost", // in-memory node doesn't support eth node; removing this line will cause an error
       zksync: true,
     },
     hardhat: {


### PR DESCRIPTION
### What :computer:

Adjust the `ethNetwork` configuration field for the `inMemoryNode` network to be set as `localhost`.

### Why :hand:

When attempting to deploy the `Greeter` contract within the template using the `inMemoryNode` network, an error occurs as depicted in the image:

![Error Screenshot](https://github.com/matter-labs/zksync-contract-templates/assets/63374472/176fb4db-f528-4bea-aa83-914036c0887b)

Upon investigation in the code, the failure is observed in the `deployer.ts` script within the `hardhat-zksync-deploy` module:

```rust
} else {
    ethWeb3Provider =
        ethNetwork === 'localhost'
            ? this._createDefaultEthProvider()
            : new ethers.providers.JsonRpcProvider((networks[ethNetwork] as HttpNetworkConfig).url);
}
```

The attempt to retrieve the `url` from the empty `ethNetwork` results in a failure. This workaround aims to resolve the issue by establishing a default provider creation in such cases (even when operations with L1 are not supported)