### PR TITLE
fix: update .gitignore in template to exclude yarn files

### DIFF
--- a/templates/hardhat/solidity/.gitignore
+++ b/templates/hardhat/solidity/.gitignore
@@ -74,8 +74,16 @@ typings/
 # Output of 'npm pack'
 *.tgz
 
-# Yarn Integrity file
+# Yarn
 .yarn-integrity
+.yarn/*
+.yarn/install-state.gz
+!.yarn/cache
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions
 
 # dotenv environment variables file
 .env

--- a/templates/hardhat/vyper/.gitignore
+++ b/templates/hardhat/vyper/.gitignore
@@ -74,8 +74,16 @@ typings/
 # Output of 'npm pack'
 *.tgz
 
-# Yarn Integrity file
+# Yarn
 .yarn-integrity
+.yarn/*
+.yarn/install-state.gz
+!.yarn/cache
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions
 
 # dotenv environment variables file
 .env

--- a/templates/hardhat_ethers5/vyper/.gitignore
+++ b/templates/hardhat_ethers5/vyper/.gitignore
@@ -74,8 +74,16 @@ typings/
 # Output of 'npm pack'
 *.tgz
 
-# Yarn Integrity file
+# Yarn
 .yarn-integrity
+.yarn/*
+.yarn/install-state.gz
+!.yarn/cache
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions
 
 # dotenv environment variables file
 .env


### PR DESCRIPTION
# What :computer: 
* Update .gitignore in template to exclude .yarn/* files.

# Why :hand:
* According to [official yarn guideline](https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored), the documents recommended what should be ignored and what should be committed, but it seems some files were still missing in this template.
* It may cause developers to commit local yarn states such as `yarn/install-state.gz` if we do not exclude them by default.

# Evidence :camera:
N/A

# Notes :memo:
N/A