### PR TITLE
chore: update zksync-ethers to latest v5 version to access `SmartAccount`

### DIFF
--- a/templates/hardhat_ethers5/solidity/package.json
+++ b/templates/hardhat_ethers5/solidity/package.json
@@ -13,7 +13,7 @@
     "test": "hardhat test --network hardhat"
   },
   "devDependencies": {
-    "@matterlabs/hardhat-zksync-deploy": "^0.8.0",
+    "@matterlabs/hardhat-zksync-deploy": "^0.9.0",
     "@matterlabs/hardhat-zksync-node": "^0.1.0",
     "@matterlabs/hardhat-zksync-solc": "^1.1.4",
     "@matterlabs/hardhat-zksync-verify": "^0.5.1",
@@ -29,6 +29,6 @@
     "mocha": "^10.2.0",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.5",
-    "zksync-ethers": "^5.0.0"
+    "zksync-ethers": "^5.7.0"
   }
 }


### PR DESCRIPTION
# What :computer: 
* Bumps zksync-ethers to latest v5 version 
* Bumps deploy to latest v5 version

# Why :hand:
* Allows devs to access SmartAccount from zksync-cli

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

<!-- All sections below are optional. You can erase any section not applicable to your Pull Request. -->

# Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code?