### PR TITLE
fix: upgrades oz to 4.9.5

### DIFF
--- a/templates/quickstart/hardhat/upgradability/package.json
+++ b/templates/quickstart/hardhat/upgradability/package.json
@@ -8,14 +8,14 @@
   "scripts": {
     "deploy": "hardhat deploy-zksync --script deploy.ts",
     "compile": "hardhat compile",
-    "clean": "hardhat clean" 
+    "clean": "hardhat clean"
   },
   "devDependencies": {
     "@matterlabs/hardhat-zksync": "^1.0.0",
     "@matterlabs/zksync-contracts": "^0.6.1",
     "@nomiclabs/hardhat-etherscan": "^3.1.7",
     "@nomicfoundation/hardhat-chai-matchers": "^2.0.6",
-    "@openzeppelin/contracts": "^4.6.0",
+    "@openzeppelin/contracts": "^4.9.5",
     "@openzeppelin/contracts-upgradeable": "4.9.5",
     "@openzeppelin/upgrades-core": "^1.32.5",
     "@types/chai": "^4.3.4",


### PR DESCRIPTION
# What :computer: 
* Upgrades OZ in template for 101 proxies examples

# Why :hand:
* Fix DEVRL-622 and DEVRL-702
* NPM does not resolve this dependency correctly and installs only 4.6.0, which is missing a required interface

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

<!-- All sections below are optional. You can erase any section not applicable to your Pull Request. -->

# Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code?