### PR TITLE
fix: update hardhat vyper template

### DIFF
--- a/templates/hardhat/vyper/package.json
+++ b/templates/hardhat/vyper/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@matterlabs/hardhat-zksync-deploy": "^1.5.0",
     "@matterlabs/hardhat-zksync-node": "^1.1.1",
-    "@matterlabs/hardhat-zksync-vyper": "^1.0.8",
+    "@matterlabs/hardhat-zksync-vyper": "^1.1.1",
     "@nomicfoundation/hardhat-verify": "^2.0.9",
     "@nomiclabs/hardhat-vyper": "^3.0.7",
     "@types/chai": "^4.3.16",


### PR DESCRIPTION
# What :computer: 

Update vyper hardhat template.

# Why :hand:

To fix issue with `zkvyper` 1.5.6 incompatibility with the hardhat plugin.
