### PR TITLE
fix: remove the latest tag for zksolc and zkvyper versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v1
       - name: Run anvil-zksync
-        uses: dutterbutter/anvil-zksync-action@v1.1.0
+        uses: dutterbutter/anvil-zksync-action@v1.2.0
       - name: Install dependencies
         run: cd templates/101/eravm && bun install
 

--- a/templates/101/eravm/hardhat.config.ts
+++ b/templates/101/eravm/hardhat.config.ts
@@ -52,7 +52,7 @@ const config: HardhatUserConfig = {
     },
   },
   zksolc: {
-    version: "latest",
+    version: "1.5.15",
     settings: {
       codegen: 'yul',
       // find all available options in the official documentation
@@ -60,7 +60,7 @@ const config: HardhatUserConfig = {
     },
   },
   solidity: {
-    version: "0.8.29",
+    version: "0.8.30",
   },
 };
 

--- a/templates/hardhat/solidity/hardhat.config.ts
+++ b/templates/hardhat/solidity/hardhat.config.ts
@@ -54,7 +54,7 @@ const config: HardhatUserConfig = {
     },
   },
   zksolc: {
-    version: "latest",
+    version: "1.5.15",
     settings: {
       codegen: 'yul',
       // find all available options in the official documentation
@@ -62,7 +62,7 @@ const config: HardhatUserConfig = {
     },
   },
   solidity: {
-    version: "0.8.29",
+    version: "0.8.30",
   },
 };
 

--- a/templates/hardhat/vyper/hardhat.config.ts
+++ b/templates/hardhat/vyper/hardhat.config.ts
@@ -12,13 +12,13 @@ import dotenv from "dotenv";
 dotenv.config();
 
 const config: HardhatUserConfig = {
-  solidity: "0.8.29",
-  // Currently, only Vyper >0.3.3
+  solidity: "0.8.30",
+  // Currently, only Vyper >=0.3.3 <=0.4.1
   vyper: {
-    version: "0.4.0",
+    version: "0.4.1",
   },
   zkvyper: {
-    version: "latest",
+    version: "1.5.10",
     settings: {
       // find all available options in the official documentation
       // https://docs.zksync.io/build/tooling/hardhat/hardhat-zksync-vyper#configuration

--- a/templates/hardhat/vyper/hardhat.config.ts
+++ b/templates/hardhat/vyper/hardhat.config.ts
@@ -15,7 +15,7 @@ const config: HardhatUserConfig = {
   solidity: "0.8.30",
   // Currently, only Vyper >=0.3.3 <=0.4.1
   vyper: {
-    version: "0.4.1",
+    version: "0.4.0",
   },
   zkvyper: {
     version: "1.5.10",

--- a/templates/quickstart/hardhat/factory/hardhat.config.ts
+++ b/templates/quickstart/hardhat/factory/hardhat.config.ts
@@ -49,7 +49,7 @@ const config: HardhatUserConfig = {
     },
   },
   zksolc: {
-    version: "latest",
+    version: "1.5.15",
     settings: {
       codegen: 'yul',
       // find all available options in the official documentation
@@ -57,7 +57,7 @@ const config: HardhatUserConfig = {
     },
   },
   solidity: {
-    version: "0.8.29",
+    version: "0.8.30",
   },
 };
 

--- a/templates/quickstart/hardhat/hello-zksync/hardhat.config.ts
+++ b/templates/quickstart/hardhat/hello-zksync/hardhat.config.ts
@@ -49,7 +49,7 @@ const config: HardhatUserConfig = {
     },
   },
   zksolc: {
-    version: "latest",
+    version: "1.5.15",
     settings: {
       codegen: 'yul',
       // find all available options in the official documentation
@@ -57,7 +57,7 @@ const config: HardhatUserConfig = {
     },
   },
   solidity: {
-    version: "0.8.29",
+    version: "0.8.30",
   },
 };
 

--- a/templates/quickstart/hardhat/paymaster/hardhat.config.ts
+++ b/templates/quickstart/hardhat/paymaster/hardhat.config.ts
@@ -49,7 +49,7 @@ const config: HardhatUserConfig = {
     },
   },
   zksolc: {
-    version: "latest",
+    version: "1.5.15",
     settings: {
       codegen: 'yul',
       // find all available options in the official documentation
@@ -57,7 +57,7 @@ const config: HardhatUserConfig = {
     },
   },
   solidity: {
-    version: "0.8.29",
+    version: "0.8.30",
   },
 };
 

--- a/templates/quickstart/hardhat/testing/hardhat.config.ts
+++ b/templates/quickstart/hardhat/testing/hardhat.config.ts
@@ -52,7 +52,7 @@ const config: HardhatUserConfig = {
     },
   },
   zksolc: {
-    version: "latest",
+    version: "1.5.15",
     settings: {
       codegen: 'yul',
       // find all available options in the official documentation
@@ -60,7 +60,7 @@ const config: HardhatUserConfig = {
     },
   },
   solidity: {
-    version: "0.8.29",
+    version: "0.8.30",
   },
 };
 

--- a/templates/quickstart/hardhat/upgradability/hardhat.config.ts
+++ b/templates/quickstart/hardhat/upgradability/hardhat.config.ts
@@ -49,7 +49,7 @@ const config: HardhatUserConfig = {
     },
   },
   zksolc: {
-    version: "latest",
+    version: "1.5.15",
     settings: {
       codegen: 'yul',
       // find all available options in the official documentation
@@ -57,7 +57,7 @@ const config: HardhatUserConfig = {
     },
   },
   solidity: {
-    version: "0.8.29",
+    version: "0.8.30",
   },
 };
 


### PR DESCRIPTION
# What :computer: 

Replaces the `latest` tag in zksolc and zkvyper templates with their latest versions.

# Why :hand:

The `latest` tag has been deprecated and then forbidden in Hardhat plugins for safety reasons.