### PR TITLE
chore: bump hardhat dep to latest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v1
       - name: Run anvil-zksync
-        uses: dutterbutter/anvil-zksync-action@v1.2.0
+        uses: dutterbutter/anvil-zksync-action@v1.3.0
       - name: Install dependencies
         run: cd templates/101/eravm && bun install
 
@@ -148,7 +148,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v1
       - name: Run anvil-zksync
-        uses: dutterbutter/anvil-zksync-action@v1.1.0
+        uses: dutterbutter/anvil-zksync-action@v1.3.0
       - name: Install dependencies
         run: cd templates/hardhat/solidity && bun install
 
@@ -187,7 +187,7 @@ jobs:
         with:
           submodules: recursive 
       - name: Run anvil-zksync
-        uses: dutterbutter/anvil-zksync-action@v1.1.0
+        uses: dutterbutter/anvil-zksync-action@v1.3.0
       - name: Install Foundry-ZKsync
         uses: dutterbutter/foundry-zksync-toolchain@main
         
@@ -212,7 +212,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v1
       - name: Run anvil-zksync
-        uses: dutterbutter/anvil-zksync-action@v1.1.0
+        uses: dutterbutter/anvil-zksync-action@v1.3.0
       - name: Install dependencies for Paymaster
         run: cd templates/quickstart/hardhat/paymaster && bun install
 
@@ -254,7 +254,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v1
       - name: Run anvil-zksync
-        uses: dutterbutter/anvil-zksync-action@v1.1.0
+        uses: dutterbutter/anvil-zksync-action@v1.3.0
       - name: Install dependencies for Testing
         run: cd templates/quickstart/hardhat/testing && bun install
 
@@ -272,7 +272,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v1
       - name: Run anvil-zksync
-        uses: dutterbutter/anvil-zksync-action@v1.1.0
+        uses: dutterbutter/anvil-zksync-action@v1.3.0
       - name: Install dependencies for Upgradability
         run: cd templates/quickstart/hardhat/upgradability && bun install
 

--- a/templates/101/eravm/package.json
+++ b/templates/101/eravm/package.json
@@ -43,7 +43,7 @@
   },
   "homepage": "https://github.com/matter-labs/zksync-contract-templates#readme",
   "devDependencies": {
-    "@matterlabs/hardhat-zksync": "^1.5.0",
+    "@matterlabs/hardhat-zksync": "^1.6.1",
     "@matterlabs/zksync-contracts": "1.0.0-alpha.9",
     "@nomicfoundation/hardhat-chai-matchers": "^2.0.8",
     "@nomicfoundation/hardhat-ignition": "^0.15.11",

--- a/templates/hardhat/solidity/package-lock.json
+++ b/templates/hardhat/solidity/package-lock.json
@@ -7,7 +7,7 @@
       "name": "zksync-hardhat-template",
       "license": "MIT",
       "devDependencies": {
-        "@matterlabs/hardhat-zksync": "^1.5.0",
+        "@matterlabs/hardhat-zksync": "^1.6.1",
         "@matterlabs/zksync-contracts": "1.0.0-alpha.9",
         "@nomicfoundation/hardhat-chai-matchers": "^2.0.8",
         "@nomicfoundation/hardhat-verify": "^2.0.13",
@@ -1492,17 +1492,19 @@
       }
     },
     "node_modules/@matterlabs/hardhat-zksync": {
-      "version": "1.5.0",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@matterlabs/hardhat-zksync/-/hardhat-zksync-1.6.1.tgz",
+      "integrity": "sha512-a7IYU6Yk1/2z/VQjjDtzZVZlVmxpPyQne7w0QdL3yIYvV4iTtWHGoylLDY4Qg8vfGm4FFgMdNXR+LxU87uuiDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@matterlabs/hardhat-zksync-deploy": "^1.7.0",
         "@matterlabs/hardhat-zksync-ethers": "^1.3.0",
-        "@matterlabs/hardhat-zksync-node": "^1.4.0",
-        "@matterlabs/hardhat-zksync-solc": "^1.3.0",
-        "@matterlabs/hardhat-zksync-telemetry": "^1.1.0",
+        "@matterlabs/hardhat-zksync-node": "^1.5.2",
+        "@matterlabs/hardhat-zksync-solc": "^1.4.0",
+        "@matterlabs/hardhat-zksync-telemetry": "^1.1.1",
         "@matterlabs/hardhat-zksync-upgradable": "^1.9.0",
-        "@matterlabs/hardhat-zksync-verify": "^1.8.0",
+        "@matterlabs/hardhat-zksync-verify": "^1.8.1",
         "@nomicfoundation/hardhat-verify": "^2.0.0",
         "@openzeppelin/upgrades-core": "^1.37.0",
         "chai": "^4.3.4",
@@ -1515,11 +1517,11 @@
       "peerDependencies": {
         "@matterlabs/hardhat-zksync-deploy": "^1.7.0",
         "@matterlabs/hardhat-zksync-ethers": "^1.3.0",
-        "@matterlabs/hardhat-zksync-node": "^1.4.0",
-        "@matterlabs/hardhat-zksync-solc": "^1.3.0",
-        "@matterlabs/hardhat-zksync-telemetry": "^1.1.0",
+        "@matterlabs/hardhat-zksync-node": "^1.5.2",
+        "@matterlabs/hardhat-zksync-solc": "^1.4.0",
+        "@matterlabs/hardhat-zksync-telemetry": "^1.1.1",
         "@matterlabs/hardhat-zksync-upgradable": "^1.9.0",
-        "@matterlabs/hardhat-zksync-verify": "^1.8.0"
+        "@matterlabs/hardhat-zksync-verify": "^1.8.1"
       }
     },
     "node_modules/@matterlabs/hardhat-zksync-deploy": {
@@ -1595,11 +1597,13 @@
       }
     },
     "node_modules/@matterlabs/hardhat-zksync-node": {
-      "version": "1.5.0",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@matterlabs/hardhat-zksync-node/-/hardhat-zksync-node-1.5.2.tgz",
+      "integrity": "sha512-I9icYktw4T09hOsajqRvZKaaQ6pmau7qkuHgPW8Azq3haK0MF+mq6ErkSqXzV6qPy9gg8mT885Xy36jMi86sbQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@matterlabs/hardhat-zksync-solc": "^1.3.2",
+        "@matterlabs/hardhat-zksync-solc": "^1.4.0",
         "@matterlabs/hardhat-zksync-telemetry": "^1.1.1",
         "axios": "^1.7.2",
         "chai": "^4.3.4",
@@ -1619,6 +1623,8 @@
     },
     "node_modules/@matterlabs/hardhat-zksync-node/node_modules/fs-extra": {
       "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1630,8 +1636,10 @@
         "node": ">=14.14"
       }
     },
-    "node_modules/@matterlabs/hardhat-zksync-node/node_modules/fs-extra/node_modules/jsonfile": {
+    "node_modules/@matterlabs/hardhat-zksync-node/node_modules/jsonfile": {
       "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1641,16 +1649,10 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/@matterlabs/hardhat-zksync-node/node_modules/fs-extra/node_modules/universalify": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/@matterlabs/hardhat-zksync-node/node_modules/semver": {
-      "version": "7.7.1",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1661,15 +1663,29 @@
       }
     },
     "node_modules/@matterlabs/hardhat-zksync-node/node_modules/undici": {
-      "version": "6.21.2",
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
       }
     },
+    "node_modules/@matterlabs/hardhat-zksync-node/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/@matterlabs/hardhat-zksync-solc": {
-      "version": "1.3.2",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@matterlabs/hardhat-zksync-solc/-/hardhat-zksync-solc-1.4.0.tgz",
+      "integrity": "sha512-g3rTEUql1qK2mePU8NrggvxkpvmkL5ljR++lioqluCQT7mjI9RHV5Cylh2UOAH+7aFUYir8dwYnlRHJ3OK7SGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1823,14 +1839,16 @@
       }
     },
     "node_modules/@matterlabs/hardhat-zksync-verify": {
-      "version": "1.8.0",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@matterlabs/hardhat-zksync-verify/-/hardhat-zksync-verify-1.8.1.tgz",
+      "integrity": "sha512-9ClF740rZbHw920bslNSfAXoF6pIUwwLcqD0utv1N71SbErvTQV8PAeiH9HE1ZwFMFYYD24ssoqjz6glufAllg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ethersproject/abi": "^5.7.0",
         "@ethersproject/address": "5.7.0",
-        "@matterlabs/hardhat-zksync-solc": "^1.3.0",
-        "@matterlabs/hardhat-zksync-telemetry": "^1.1.0",
+        "@matterlabs/hardhat-zksync-solc": "^1.3.2",
+        "@matterlabs/hardhat-zksync-telemetry": "^1.1.1",
         "@nomicfoundation/hardhat-verify": "^2.0.8",
         "axios": "^1.7.2",
         "cbor": "^9.0.2",
@@ -1848,6 +1866,8 @@
     },
     "node_modules/@matterlabs/hardhat-zksync-verify/node_modules/@ethersproject/address": {
       "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
+      "integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
       "dev": true,
       "funding": [
         {
@@ -1870,6 +1890,8 @@
     },
     "node_modules/@matterlabs/hardhat-zksync-verify/node_modules/cbor": {
       "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-9.0.2.tgz",
+      "integrity": "sha512-JPypkxsB10s9QOWwa6zwPzqE1Md3vqpPc+cai4sAecuCsRyAtAl/pMyhPlMbT/xtPnm2dznJZYRLui57qiRhaQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1880,7 +1902,9 @@
       }
     },
     "node_modules/@matterlabs/hardhat-zksync-verify/node_modules/semver": {
-      "version": "7.7.1",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -5575,6 +5599,8 @@
     },
     "node_modules/fill-keys": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+      "integrity": "sha512-tcgI872xXjwFF4xgQmLxi76GnwJG3g/3isB1l4/G5Z4zrbddGpBjqZCO9oEAcB5wX0Hj/5iQB3toxfO7in1hHA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6306,6 +6332,8 @@
     },
     "node_modules/is-object": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
+      "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -6562,6 +6590,8 @@
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -6769,6 +6799,8 @@
     },
     "node_modules/module-not-found-error": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+      "integrity": "sha512-pEk4ECWQXV6z2zjhRZUongnLJNUeGQJ3w6OQ5ctGwD+i5o93qjRQUk2Rt6VdNeu3sEP0AB4LcfvdebpxBRVr4g==",
       "dev": true,
       "license": "MIT"
     },
@@ -7133,6 +7165,8 @@
     },
     "node_modules/proxyquire": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.3.tgz",
+      "integrity": "sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/templates/hardhat/solidity/package.json
+++ b/templates/hardhat/solidity/package.json
@@ -15,7 +15,7 @@
     "test": "hardhat test --network hardhat"
   },
   "devDependencies": {
-    "@matterlabs/hardhat-zksync": "^1.5.0",
+    "@matterlabs/hardhat-zksync": "^1.6.1",
     "@matterlabs/zksync-contracts": "1.0.0-alpha.9",
     "@nomicfoundation/hardhat-chai-matchers": "^2.0.8",
     "@nomicfoundation/hardhat-verify": "^2.0.13",

--- a/templates/hardhat/vyper/package.json
+++ b/templates/hardhat/vyper/package.json
@@ -13,7 +13,7 @@
     "test": "hardhat test --network hardhat"
   },
   "devDependencies": {
-    "@matterlabs/hardhat-zksync": "^1.6.0",
+    "@matterlabs/hardhat-zksync": "^1.6.1",
     "@matterlabs/hardhat-zksync-vyper": "^1.2.1",
     "@nomicfoundation/hardhat-chai-matchers": "^2.0.8",
     "@nomicfoundation/hardhat-verify": "^2.0.13",

--- a/templates/quickstart/hardhat/factory/package.json
+++ b/templates/quickstart/hardhat/factory/package.json
@@ -11,7 +11,7 @@
     "clean": "hardhat clean"
   },
   "devDependencies": {
-    "@matterlabs/hardhat-zksync": "^1.5.0",
+    "@matterlabs/hardhat-zksync": "^1.6.1",
     "@matterlabs/zksync-contracts": "1.0.0-alpha.9",
     "@nomiclabs/hardhat-etherscan": "^3.1.8",
     "@nomicfoundation/hardhat-chai-matchers": "^2.0.8",

--- a/templates/quickstart/hardhat/hello-zksync/package.json
+++ b/templates/quickstart/hardhat/hello-zksync/package.json
@@ -11,7 +11,7 @@
     "clean": "hardhat clean"
   },
   "devDependencies": {
-    "@matterlabs/hardhat-zksync": "^1.5.0",
+    "@matterlabs/hardhat-zksync": "^1.6.1",
     "@matterlabs/zksync-contracts": "1.0.0-alpha.9",
     "@nomiclabs/hardhat-etherscan": "^3.1.8",
     "@nomicfoundation/hardhat-chai-matchers": "^2.0.8",

--- a/templates/quickstart/hardhat/paymaster/package.json
+++ b/templates/quickstart/hardhat/paymaster/package.json
@@ -20,7 +20,7 @@
     "clean": "hardhat clean"
   },
   "devDependencies": {
-    "@matterlabs/hardhat-zksync": "^1.5.0",
+    "@matterlabs/hardhat-zksync": "^1.6.1",
     "@matterlabs/zksync-contracts": "1.0.0-alpha.9",
     "@nomiclabs/hardhat-etherscan": "^3.1.8",
     "@nomicfoundation/hardhat-chai-matchers": "^2.0.8",

--- a/templates/quickstart/hardhat/testing/package.json
+++ b/templates/quickstart/hardhat/testing/package.json
@@ -12,7 +12,7 @@
     "test": "hardhat test --network hardhat"
   },
   "devDependencies": {
-    "@matterlabs/hardhat-zksync": "^1.5.0",
+    "@matterlabs/hardhat-zksync": "^1.6.1",
     "@matterlabs/zksync-contracts": "1.0.0-alpha.9",
     "@nomicfoundation/hardhat-chai-matchers": "^2.0.8",
     "@nomicfoundation/hardhat-toolbox": "^5.0.0",

--- a/templates/quickstart/hardhat/upgradability/package.json
+++ b/templates/quickstart/hardhat/upgradability/package.json
@@ -16,7 +16,7 @@
     "clean": "hardhat clean"
   },
   "devDependencies": {
-    "@matterlabs/hardhat-zksync": "^1.5.0",
+    "@matterlabs/hardhat-zksync": "^1.6.1",
     "@matterlabs/zksync-contracts": "1.0.0-alpha.9",
     "@nomiclabs/hardhat-etherscan": "^3.1.8",
     "@nomicfoundation/hardhat-chai-matchers": "^2.0.8",


### PR DESCRIPTION
# What :computer: 
* Bump to 1.6.1

# Why :hand:
* Stays with latest

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

<!-- All sections below are optional. You can erase any section not applicable to your Pull Request. -->

# Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code?